### PR TITLE
Construct ImportDictionary, add AddedBySceneImport flag

### DIFF
--- a/KKAPI/Chara/CharaCustomFunctionController.cs
+++ b/KKAPI/Chara/CharaCustomFunctionController.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.Collections;
-using ExtensibleSaveFormat;
+﻿using ExtensibleSaveFormat;
 using KKAPI.Maker;
+using System;
+using System.Collections;
 using UniRx;
 using UnityEngine;
 
@@ -37,6 +37,11 @@ namespace KKAPI.Chara
         /// True if this controller has been initialized
         /// </summary>
         public bool Started { get; private set; }
+
+        /// <summary>
+        /// True when this character was added by importing a scene. Will revert to false after the controllers's first OnReload event.
+        /// </summary>
+        public bool AddedBySceneImport { get; internal set; }
 
         /// <summary>
         /// Get extended data based on supplied ExtendedDataId. When in chara maker loads data from character that's being loaded. 
@@ -165,6 +170,8 @@ namespace KKAPI.Chara
         {
             ChaControl = GetComponent<ChaControl>();
             CurrentCoordinate = new BehaviorSubject<ChaFileDefine.CoordinateType>((ChaFileDefine.CoordinateType)ChaControl.fileStatus.coordinateType);
+            if (CharacterApi.DoingImport)
+                AddedBySceneImport = true;
         }
 
         /// <summary>
@@ -174,6 +181,7 @@ namespace KKAPI.Chara
         {
             Started = true;
             OnReload(KoikatuAPI.GetCurrentGameMode());
+            AddedBySceneImport = false;
         }
     }
 }

--- a/KKAPI/Chara/CharacterApi.Hooks.cs
+++ b/KKAPI/Chara/CharacterApi.Hooks.cs
@@ -1,10 +1,13 @@
-﻿using System;
-using System.Reflection;
-using BepInEx.Logging;
+﻿using BepInEx.Logging;
 using ChaCustom;
 using Harmony;
 using KKAPI.Maker;
 using Studio;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
 using UnityEngine;
 using UnityEngine.UI;
 using Logger = BepInEx.Logger;
@@ -141,6 +144,66 @@ namespace KKAPI.Chara
             public static void clothesFileControl_InitializePostHook()
             {
                 ClothesFileControlLoading = false;
+            }
+
+            [HarmonyPrefix, HarmonyPatch(typeof(global::Studio.Studio), nameof(global::Studio.Studio.ImportScene))]
+            public static void ImportScenePrefix()
+            {
+                ImportDictionary.Clear();
+                DoingImport = true;
+            }
+
+            [HarmonyPostfix, HarmonyPatch(typeof(global::Studio.Studio), nameof(global::Studio.Studio.ImportScene))]
+            public static void ImportScenePostfix()
+            {
+                DoingImport = false;
+            }
+
+            [HarmonyPrefix, HarmonyPatch(typeof(global::Studio.Studio), nameof(global::Studio.Studio.LoadScene))]
+            public static void LoadScenePrefix()
+            {
+                ImportDictionary.Clear();
+            }
+
+            [HarmonyPrefix, HarmonyPatch(typeof(global::Studio.Studio), nameof(global::Studio.Studio.LoadSceneCoroutine))]
+            public static void LoadSceneCoroutinePrefix()
+            {
+                ImportDictionary.Clear();
+            }
+
+            [HarmonyPrefix, HarmonyPatch(typeof(global::Studio.Studio), nameof(global::Studio.Studio.InitScene))]
+            public static void InitScenePrefix()
+            {
+                ImportDictionary.Clear();
+            }
+
+            [HarmonyPostfix, HarmonyPatch(typeof(global::Studio.Studio), nameof(global::Studio.Studio.GetNewIndex))]
+            public static void GetNewIndex(int __result)
+            {
+                NewIndex = __result;
+            }
+            /// <summary>
+            /// The original code reads the dicKey of an object on import and does nothing with it. Capture that variable and use it to construct an import dictionary.
+            /// </summary>
+            [HarmonyTranspiler, HarmonyPatch(typeof(ObjectInfo), nameof(ObjectInfo.Load))]
+            public static IEnumerable<CodeInstruction> InitBaseCustomTextureBodyTranspiler(IEnumerable<CodeInstruction> instructions)
+            {
+                List<CodeInstruction> instructionsList = instructions.ToList();
+
+                foreach (var x in instructionsList)
+                {
+                    if (x.opcode == OpCodes.Pop)
+                    {
+                        x.opcode = OpCodes.Call;
+                        x.operand = typeof(Hooks).GetMethod(nameof(Hooks.SetImportDictionary), AccessTools.all);
+                    }
+                }
+                return instructions;
+            }
+
+            private static void SetImportDictionary(int originalDicKey)
+            {
+                ImportDictionary[originalDicKey] = NewIndex;
             }
         }
     }

--- a/KKAPI/Chara/CharacterApi.cs
+++ b/KKAPI/Chara/CharacterApi.cs
@@ -1,12 +1,12 @@
-﻿using System;
+﻿using BepInEx.Logging;
+using ExtensibleSaveFormat;
+using Harmony;
+using KKAPI.Maker;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using BepInEx.Logging;
-using ExtensibleSaveFormat;
-using Harmony;
-using KKAPI.Maker;
 using Logger = BepInEx.Logger;
 
 namespace KKAPI.Chara
@@ -21,6 +21,12 @@ namespace KKAPI.Chara
 
         private static readonly List<KeyValuePair<Type, string>> RegisteredHandlers = new List<KeyValuePair<Type, string>>();
         private static readonly List<CopyExtendedDataFunc> DataCopiers = new List<CopyExtendedDataFunc>();
+        internal static bool DoingImport = false;
+        /// <summary>
+        /// A dictionary of old dicKey and new dicKey generated on scene import
+        /// </summary>
+        public static Dictionary<int, int> ImportDictionary = new Dictionary<int, int>();
+        private static int NewIndex;
 
         /// <summary>
         /// Override to supply custom extended data copying logic.


### PR DESCRIPTION
Creates a dictionary of original dicKey and new dicKey when a scene is imported which will be useful for any plugin that needs to run code on object on import. Also sets a flag called AddedBySceneImport to the CharaCustomFunctionController which will be true on the first OnReload when a character is created due to importing a scene.